### PR TITLE
Add lead management with status tracking and reminders

### DIFF
--- a/add_lead.php
+++ b/add_lead.php
@@ -1,0 +1,29 @@
+<?php
+header('Content-Type: application/json');
+include 'config.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $name  = trim($_POST['name'] ?? '');
+    $email = trim($_POST['email'] ?? '');
+    $phone = trim($_POST['phone'] ?? '');
+    $next  = trim($_POST['next_followup'] ?? '');
+
+    if ($name === '') {
+        echo json_encode(['status' => 'error', 'message' => 'Name is required']);
+        exit;
+    }
+
+    $sql = "INSERT INTO leads (name, email, phone, next_followup) VALUES (?, ?, ?, ?)";
+    $stmt = $conn->prepare($sql);
+    if (!$stmt) {
+        echo json_encode(['status' => 'error', 'message' => $conn->error]);
+        exit;
+    }
+    $stmt->bind_param('ssss', $name, $email, $phone, $next);
+    if ($stmt->execute()) {
+        echo json_encode(['status' => 'success']);
+    } else {
+        echo json_encode(['status' => 'error', 'message' => $stmt->error]);
+    }
+}
+?>

--- a/includes/lead-modal.php
+++ b/includes/lead-modal.php
@@ -1,0 +1,76 @@
+<!-- Add Lead Modal -->
+<div class="modal fade" id="leadModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header bg-light p-3">
+        <h5 class="modal-title">Add Lead</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <form id="leadForm">
+        <div class="modal-body">
+          <div class="mb-3">
+            <label class="form-label">Name</label>
+            <input type="text" class="form-control" name="name" required>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Email</label>
+            <input type="email" class="form-control" name="email">
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Phone</label>
+            <input type="text" class="form-control" name="phone">
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Next Follow-up</label>
+            <input type="date" class="form-control" name="next_followup">
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-light" data-bs-dismiss="modal">Close</button>
+          <button type="submit" class="btn btn-primary">Save</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+
+<div id="leadToastSuccess" class="toast align-items-center text-bg-success border-0" role="alert" aria-live="assertive" aria-atomic="true">
+  <div class="d-flex">
+    <div class="toast-body">Lead saved!</div>
+    <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast"></button>
+  </div>
+</div>
+<div id="leadToastError" class="toast align-items-center text-bg-danger border-0" role="alert" aria-live="assertive" aria-atomic="true">
+  <div class="d-flex">
+    <div class="toast-body">Error</div>
+    <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast"></button>
+  </div>
+</div>
+
+<script>
+document.getElementById('leadForm').addEventListener('submit', function(e){
+  e.preventDefault();
+  let form = this;
+  fetch('add_lead.php', {method: 'POST', body: new FormData(form)})
+    .then(res => res.json())
+    .then(data => {
+      if(data.status === 'success'){
+        form.reset();
+        let modalEl = document.getElementById('leadModal');
+        let modal = bootstrap.Modal.getInstance(modalEl);
+        if(modal) modal.hide();
+        new bootstrap.Toast(document.getElementById('leadToastSuccess')).show();
+        if(typeof refreshLeads === 'function'){ refreshLeads(); }
+      }else{
+        let t = document.getElementById('leadToastError');
+        t.querySelector('.toast-body').innerText = data.message || 'Error';
+        new bootstrap.Toast(t).show();
+      }
+    })
+    .catch(() => {
+      let t = document.getElementById('leadToastError');
+      t.querySelector('.toast-body').innerText = 'Server error';
+      new bootstrap.Toast(t).show();
+    });
+});
+</script>

--- a/includes/sidebar.php
+++ b/includes/sidebar.php
@@ -175,6 +175,12 @@
                     </a>
                 </li>
 
+                <li class="nav-item">
+                    <a class="nav-link menu-link" href="leads.php">
+                        <i class="ri-user-follow-line"></i> <span data-key="t-leads">Leads</span>
+                    </a>
+                </li>
+
 
                 <!-- <li class="nav-item">
                     <a class="nav-link menu-link" href="#sidebarDashboards" data-bs-toggle="collapse"

--- a/index.php
+++ b/index.php
@@ -3,7 +3,17 @@
 
 
 <?php include 'includes/auth.php'; ?>
-<?php include 'includes/common-header.php' ?>
+<?php include 'includes/common-header.php'; ?>
+<?php include 'config.php'; ?>
+<?php
+$reminders = [];
+$reminderQuery = $conn->query("SELECT name, next_followup FROM leads WHERE next_followup <= CURDATE() AND status <> 'Closed'");
+if ($reminderQuery) {
+    while ($row = $reminderQuery->fetch_assoc()) {
+        $reminders[] = $row;
+    }
+}
+?>
 
 
 <div class="main-content">
@@ -23,12 +33,25 @@
                                         <p class="text-muted mb-0">Here's what's happening with your store
                                             today.</p>
                                     </div>
+                                    <div class="mt-3 mt-lg-0">
+                                        <button type="button" class="btn btn-success" data-bs-toggle="modal" data-bs-target="#leadModal">Add Lead</button>
+                                    </div>
                                 </div>
                                 <!-- end card header -->
                             </div>
                             <!--end col-->
                         </div>
                         <!--end row-->
+                        <?php if (!empty($reminders)): ?>
+                        <div class="alert alert-warning">
+                            <strong>Follow-up reminders:</strong>
+                            <ul class="mb-0">
+                                <?php foreach ($reminders as $r): ?>
+                                <li><?php echo htmlspecialchars($r['name']); ?> - <?php echo $r['next_followup']; ?></li>
+                                <?php endforeach; ?>
+                            </ul>
+                        </div>
+                        <?php endif; ?>
 
                         <div class="row">
                             <div class="col-xl-3 col-md-6">
@@ -1513,4 +1536,5 @@
     <?php include 'includes/footer.php'?>
 </div>
 
-<?php include 'includes/common-footer.php' ?>
+<?php include 'includes/lead-modal.php'; ?>
+<?php include 'includes/common-footer.php'; ?>

--- a/leads.php
+++ b/leads.php
@@ -1,0 +1,75 @@
+<?php include 'includes/common-header.php' ?>
+
+<div class="main-content">
+    <div class="page-content">
+        <div class="container-fluid">
+            <div class="row">
+                <div class="col-12">
+                    <div class="page-title-box d-sm-flex align-items-center justify-content-between bg-galaxy-transparent">
+                        <h4 class="mb-sm-0">Leads</h4>
+                        <div class="page-title-right">
+                            <button type="button" class="btn btn-success" data-bs-toggle="modal" data-bs-target="#leadModal">Add Lead</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="row">
+                <div class="col-lg-12">
+                    <div class="card">
+                        <div class="card-header">
+                            <h4 class="card-title mb-0">Lead Management</h4>
+                        </div>
+                        <div class="card-body">
+                            <div class="table-responsive table-card mt-3 mb-1">
+                                <table class="table align-middle table-nowrap">
+                                    <thead class="table-light">
+                                        <tr>
+                                            <th>Name</th>
+                                            <th>Email</th>
+                                            <th>Phone</th>
+                                            <th>Status</th>
+                                            <th>Next Follow-up</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody id="leadTableBody">
+                                        <?php include 'leads_list.php'; ?>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <?php include 'includes/footer.php'?>
+</div>
+<?php include 'includes/lead-modal.php'; ?>
+<?php include 'includes/common-footer.php' ?>
+
+<script>
+function attachLeadEvents(){
+  document.querySelectorAll('.status-select, .next-followup').forEach(function(el){
+    el.addEventListener('change', function(){
+      let row = this.closest('tr');
+      let id = this.dataset.id;
+      let status = row.querySelector('.status-select').value;
+      let next = row.querySelector('.next-followup').value;
+      fetch('update_lead_status.php', {
+        method:'POST',
+        headers:{'Content-Type':'application/x-www-form-urlencoded'},
+        body:new URLSearchParams({id:id, status:status, next_followup:next})
+      });
+    });
+  });
+}
+function refreshLeads(){
+  fetch('leads_list.php').then(r=>r.text()).then(html=>{
+    document.getElementById('leadTableBody').innerHTML = html;
+    attachLeadEvents();
+  });
+}
+attachLeadEvents();
+</script>

--- a/leads.sql
+++ b/leads.sql
@@ -1,0 +1,11 @@
+CREATE TABLE `leads` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(100) NOT NULL,
+  `email` varchar(100) DEFAULT NULL,
+  `phone` varchar(20) DEFAULT NULL,
+  `status` enum('Enquiry','Site Visit','Booking','Closed') NOT NULL DEFAULT 'Enquiry',
+  `next_followup` date DEFAULT NULL,
+  `created_at` timestamp NOT NULL DEFAULT current_timestamp(),
+  `updated_at` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;

--- a/leads_list.php
+++ b/leads_list.php
@@ -1,0 +1,25 @@
+<?php
+include 'config.php';
+$leads = $conn->query("SELECT * FROM leads ORDER BY created_at DESC");
+while ($lead = $leads->fetch_assoc()):
+?>
+<tr>
+    <td><?php echo htmlspecialchars($lead['name']); ?></td>
+    <td><?php echo htmlspecialchars($lead['email']); ?></td>
+    <td><?php echo htmlspecialchars($lead['phone']); ?></td>
+    <td>
+        <select class="form-select form-select-sm status-select" data-id="<?php echo $lead['id']; ?>">
+            <?php
+            $statuses = ['Enquiry','Site Visit','Booking','Closed'];
+            foreach ($statuses as $s):
+                $sel = $lead['status'] === $s ? 'selected' : '';
+                echo "<option value='$s' $sel>$s</option>";
+            endforeach;
+            ?>
+        </select>
+    </td>
+    <td>
+        <input type="date" class="form-control form-control-sm next-followup" data-id="<?php echo $lead['id']; ?>" value="<?php echo $lead['next_followup']; ?>" />
+    </td>
+</tr>
+<?php endwhile; ?>

--- a/update_lead_status.php
+++ b/update_lead_status.php
@@ -1,0 +1,28 @@
+<?php
+header('Content-Type: application/json');
+include 'config.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $id = intval($_POST['id'] ?? 0);
+    $status = $_POST['status'] ?? '';
+    $next = $_POST['next_followup'] ?? null;
+
+    if ($id <= 0 || $status === '') {
+        echo json_encode(['status' => 'error', 'message' => 'Invalid data']);
+        exit;
+    }
+
+    $sql = "UPDATE leads SET status = ?, next_followup = ? WHERE id = ?";
+    $stmt = $conn->prepare($sql);
+    if (!$stmt) {
+        echo json_encode(['status' => 'error', 'message' => $conn->error]);
+        exit;
+    }
+    $stmt->bind_param('ssi', $status, $next, $id);
+    if ($stmt->execute()) {
+        echo json_encode(['status' => 'success']);
+    } else {
+        echo json_encode(['status' => 'error', 'message' => $stmt->error]);
+    }
+}
+?>


### PR DESCRIPTION
## Summary
- Add database schema for leads with status and follow-up fields.
- Implement lead management page with status updates and follow-up dates.
- Enable adding leads from dashboard and show reminders for due follow-ups.

## Testing
- `php -l add_lead.php`
- `php -l leads.php`
- `php -l index.php`
- `php -l includes/sidebar.php`

------
https://chatgpt.com/codex/tasks/task_e_68a6c283e1b48324a15f4ad524628fe6