### PR TITLE
Add reporting and analytics for leads

### DIFF
--- a/add_lead.php
+++ b/add_lead.php
@@ -6,6 +6,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $name  = trim($_POST['name'] ?? '');
     $email = trim($_POST['email'] ?? '');
     $phone = trim($_POST['phone'] ?? '');
+    $partner = trim($_POST['partner'] ?? '');
+    $project = trim($_POST['project'] ?? '');
     $next  = trim($_POST['next_followup'] ?? '');
 
     if ($name === '') {
@@ -13,13 +15,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         exit;
     }
 
-    $sql = "INSERT INTO leads (name, email, phone, next_followup) VALUES (?, ?, ?, ?)";
+    $sql = "INSERT INTO leads (name, email, phone, partner, project, next_followup) VALUES (?, ?, ?, ?, ?, ?)";
     $stmt = $conn->prepare($sql);
     if (!$stmt) {
         echo json_encode(['status' => 'error', 'message' => $conn->error]);
         exit;
     }
-    $stmt->bind_param('ssss', $name, $email, $phone, $next);
+    $stmt->bind_param('ssssss', $name, $email, $phone, $partner, $project, $next);
     if ($stmt->execute()) {
         echo json_encode(['status' => 'success']);
     } else {

--- a/includes/lead-modal.php
+++ b/includes/lead-modal.php
@@ -21,6 +21,14 @@
             <input type="text" class="form-control" name="phone">
           </div>
           <div class="mb-3">
+            <label class="form-label">Partner</label>
+            <input type="text" class="form-control" name="partner">
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Project</label>
+            <input type="text" class="form-control" name="project">
+          </div>
+          <div class="mb-3">
             <label class="form-label">Next Follow-up</label>
             <input type="date" class="form-control" name="next_followup">
           </div>

--- a/includes/sidebar.php
+++ b/includes/sidebar.php
@@ -181,6 +181,12 @@
                     </a>
                 </li>
 
+                <li class="nav-item">
+                    <a class="nav-link menu-link" href="reports.php">
+                        <i class="ri-bar-chart-line"></i> <span data-key="t-reports">Reports</span>
+                    </a>
+                </li>
+
 
                 <!-- <li class="nav-item">
                     <a class="nav-link menu-link" href="#sidebarDashboards" data-bs-toggle="collapse"

--- a/leads.php
+++ b/leads.php
@@ -28,6 +28,8 @@
                                             <th>Name</th>
                                             <th>Email</th>
                                             <th>Phone</th>
+                                            <th>Partner</th>
+                                            <th>Project</th>
                                             <th>Status</th>
                                             <th>Next Follow-up</th>
                                         </tr>

--- a/leads.sql
+++ b/leads.sql
@@ -3,6 +3,8 @@ CREATE TABLE `leads` (
   `name` varchar(100) NOT NULL,
   `email` varchar(100) DEFAULT NULL,
   `phone` varchar(20) DEFAULT NULL,
+  `partner` varchar(100) DEFAULT NULL,
+  `project` varchar(100) DEFAULT NULL,
   `status` enum('Enquiry','Site Visit','Booking','Closed') NOT NULL DEFAULT 'Enquiry',
   `next_followup` date DEFAULT NULL,
   `created_at` timestamp NOT NULL DEFAULT current_timestamp(),

--- a/leads_list.php
+++ b/leads_list.php
@@ -7,6 +7,8 @@ while ($lead = $leads->fetch_assoc()):
     <td><?php echo htmlspecialchars($lead['name']); ?></td>
     <td><?php echo htmlspecialchars($lead['email']); ?></td>
     <td><?php echo htmlspecialchars($lead['phone']); ?></td>
+    <td><?php echo htmlspecialchars($lead['partner']); ?></td>
+    <td><?php echo htmlspecialchars($lead['project']); ?></td>
     <td>
         <select class="form-select form-select-sm status-select" data-id="<?php echo $lead['id']; ?>">
             <?php

--- a/reports.php
+++ b/reports.php
@@ -1,0 +1,107 @@
+<?php include 'includes/auth.php'; ?>
+<?php include 'includes/common-header.php'; ?>
+<div class="main-content">
+  <div class="page-content">
+    <div class="container-fluid">
+      <div class="row">
+        <div class="col-12">
+          <div class="page-title-box d-sm-flex align-items-center justify-content-between bg-galaxy-transparent">
+            <h4 class="mb-sm-0">Reports</h4>
+          </div>
+        </div>
+      </div>
+      <?php include 'config.php';
+        $start = $_GET['start'] ?? '';
+        $end = $_GET['end'] ?? '';
+        $where = '';
+        if ($start && $end) {
+          $where = "WHERE created_at BETWEEN '". $conn->real_escape_string($start) ." 00:00:00' AND '".$conn->real_escape_string($end)." 23:59:59'";
+        }
+        $sql = "SELECT partner, project, COUNT(*) AS leads, SUM(CASE WHEN status='Closed' THEN 1 ELSE 0 END) AS closed FROM leads $where GROUP BY partner, project";
+        $report = $conn->query($sql);
+        $leaderSql = "SELECT partner, SUM(CASE WHEN status='Closed' THEN 1 ELSE 0 END) AS closed FROM leads $where GROUP BY partner ORDER BY closed DESC";
+        $leaders = $conn->query($leaderSql);
+      ?>
+      <div class="row">
+        <div class="col-lg-12">
+          <div class="card">
+            <div class="card-header">
+              <h4 class="card-title mb-0">Sales Performance</h4>
+            </div>
+            <div class="card-body">
+              <form class="row g-3 mb-3">
+                <div class="col-auto">
+                  <input type="date" class="form-control" name="start" value="<?php echo htmlspecialchars($start); ?>">
+                </div>
+                <div class="col-auto">
+                  <input type="date" class="form-control" name="end" value="<?php echo htmlspecialchars($end); ?>">
+                </div>
+                <div class="col-auto">
+                  <button type="submit" class="btn btn-primary">Filter</button>
+                </div>
+              </form>
+              <div class="table-responsive">
+                <table class="table align-middle table-nowrap">
+                  <thead class="table-light">
+                    <tr>
+                      <th>Partner</th>
+                      <th>Project</th>
+                      <th>Leads</th>
+                      <th>Closed</th>
+                      <th>Conversion %</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <?php while($row = $report->fetch_assoc()):
+                      $rate = $row['leads'] ? round(($row['closed'] / $row['leads']) * 100, 2) : 0; ?>
+                    <tr>
+                      <td><?php echo htmlspecialchars($row['partner']); ?></td>
+                      <td><?php echo htmlspecialchars($row['project']); ?></td>
+                      <td><?php echo $row['leads']; ?></td>
+                      <td><?php echo $row['closed']; ?></td>
+                      <td><?php echo $rate; ?>%</td>
+                    </tr>
+                    <?php endwhile; ?>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-lg-12">
+          <div class="card">
+            <div class="card-header">
+              <h4 class="card-title mb-0">Leaderboard</h4>
+            </div>
+            <div class="card-body">
+              <div class="table-responsive">
+                <table class="table align-middle table-nowrap">
+                  <thead class="table-light">
+                    <tr>
+                      <th>Rank</th>
+                      <th>Partner</th>
+                      <th>Closed Deals</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <?php $rank = 1; while($row = $leaders->fetch_assoc()): ?>
+                    <tr>
+                      <td><?php echo $rank++; ?></td>
+                      <td><?php echo htmlspecialchars($row['partner']); ?></td>
+                      <td><?php echo $row['closed']; ?></td>
+                    </tr>
+                    <?php endwhile; ?>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <?php include 'includes/footer.php'; ?>
+</div>
+<?php include 'includes/common-footer.php'; ?>


### PR DESCRIPTION
## Summary
- Track partner and project on leads and expose fields in lead form and listings
- Add reporting page with sales performance, conversion rates, and leaderboard
- Link reports into sidebar navigation

## Testing
- `php -l add_lead.php`
- `php -l includes/lead-modal.php`
- `php -l leads.php`
- `php -l leads_list.php`
- `php -l reports.php`
- `php -l includes/sidebar.php`


------
https://chatgpt.com/codex/tasks/task_e_68a6c505b86c8324b9b74afef7565044