### PR TITLE
Fix session initialization to display dashboard

### DIFF
--- a/includes/auth.php
+++ b/includes/auth.php
@@ -1,5 +1,7 @@
 <?php
-session_start();
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
 
 if (!isset($_SESSION['user_id'])) {
     header("Location: signin.php"); // Redirect to login if not logged in

--- a/index.php
+++ b/index.php
@@ -1,7 +1,3 @@
-
-
-
-
 <?php include 'includes/auth.php'; ?>
 <?php include 'includes/common-header.php'; ?>
 <?php include 'config.php'; ?>

--- a/property-details.php
+++ b/property-details.php
@@ -1,4 +1,3 @@
-
 <?php include 'includes/auth.php'; ?>
 
 <?php include 'includes/common-header.php' ?>

--- a/users.php
+++ b/users.php
@@ -1,4 +1,3 @@
-
 <?php include 'includes/auth.php'; ?>
 
 <?php include 'includes/common-header.php' ?>


### PR DESCRIPTION
## Summary
- Remove leading whitespace from dashboard and related pages so session headers can be sent cleanly
- Start PHP sessions only when needed to avoid warnings

## Testing
- `php -l index.php property-details.php users.php includes/auth.php`
- `php index.php`

------
https://chatgpt.com/codex/tasks/task_e_68a6dc864db883248b44e6409eb663e5